### PR TITLE
Use alpnprotocol from http2session

### DIFF
--- a/dist/initHttp2Express.js
+++ b/dist/initHttp2Express.js
@@ -8,9 +8,9 @@ var initHttp2Express = function initHttp2Express(app) {
     req.res = res;
     res.req = req;
     req.next = next;
-    var _ref = req.httpVersion === '2.0' ? req.stream.session : req,
-      socket = _ref.socket;
-    if (socket.alpnProtocol && (socket.alpnProtocol === 'h2' || socket.alpnProtocol === 'h2c')) {
+    const alpnProtocol = req.httpVersion === '2.0' ? req.stream.session.alpnProtocol : "h1";
+
+    if (alpnProtocol && (alpnProtocol === 'h2' || alpnProtocol === 'h2c')) {
       Object.setPrototypeOf(req, app.http2Request);
       Object.setPrototypeOf(res, app.http2Response);
     } else {

--- a/src/initHttp2Express.js
+++ b/src/initHttp2Express.js
@@ -6,8 +6,9 @@ const initHttp2Express = (app) => (req, res, next) => {
   res.req = req;
   req.next = next;
 
-  const { socket } = req.httpVersion === '2.0' ? req.stream.session : req;
-  if (socket.alpnProtocol && (socket.alpnProtocol === 'h2' || socket.alpnProtocol === 'h2c')) {
+  const alpnProtocol = req.httpVersion === '2.0' ? req.stream.session.alpnProtocol : "h1";
+
+  if (alpnProtocol && (alpnProtocol === 'h2' || alpnProtocol === 'h2c')) {
     Object.setPrototypeOf(req, app.http2Request);
     Object.setPrototypeOf(res, app.http2Response);
   } else {


### PR DESCRIPTION
When trying to create an application which requires h2c protocol(using `http2.createServer`), i got the following error: 
```
TypeError: Cannot read properties of undefined (reading 'readable') at IncomingMessage._read (node:_http_incoming:211:19) at Readable.read (node:internal/streams/readable:739:12) at resume_ (node:internal/streams/readable:1257:12) at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
throw er; // Unhandled 'error' event
at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
at resume_ (node:internal/streams/readable:1257:12)
at Readable.read (node:internal/streams/readable:741:7)
at errorOrDestroy (node:internal/streams/destroy:238:7)
at emitErrorNT (node:internal/streams/destroy:169:8)
Emitted 'error' event on IncomingMessage instance at:
```
This was because `socket.alpnProtocol` was `undefined` when using h2c protocol, and instead entered else block.

When using [alpnProtocol](https://nodejs.org/api/http2.html#http2sessionalpnprotocol) in the session itself instead of the socket, it started working for me.

Don't know if this is the correct way, but at least it works for me ☺️