### PR TITLE
Add support for express v5

### DIFF
--- a/src/initHttp2Express.js
+++ b/src/initHttp2Express.js
@@ -1,14 +1,12 @@
+const { isHttp2Request, setPoweredBy } = require("./util");
+
 const initHttp2Express = (app) => (req, res, next) => {
-  if (app.enabled('x-powered-by')) {
-    res.setHeader('X-Powered-By', 'HTTP/2 Express (http2-express)');
-  }
+  setPoweredBy(app, res);
   req.res = res;
   res.req = req;
   req.next = next;
 
-  const alpnProtocol = req.httpVersion === '2.0' ? req.stream.session.alpnProtocol : 'h1';
-
-  if (alpnProtocol && (alpnProtocol === 'h2' || alpnProtocol === 'h2c')) {
+  if (isHttp2Request(req)) {
     Object.setPrototypeOf(req, app.http2Request);
     Object.setPrototypeOf(res, app.http2Response);
   } else {

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,10 @@
+exports.setPoweredBy = (app, res) => {
+  if (app.enabled('x-powered-by')) {
+    res.setHeader('X-Powered-By', 'HTTP/2 Express (http2-express)');
+  }
+}
+
+exports.isHttp2Request = (req) => {
+  const alpnProtocol = req.httpVersion === '2.0' ? req.stream.session.alpnProtocol : 'h1';
+  return alpnProtocol && (alpnProtocol === 'h2' || alpnProtocol === 'h2c');
+}


### PR DESCRIPTION
Thank you for creating such a great library. I was able to make it 
  work with Express v5, so I'm sending you the changes.

## Changes for altering prototype

In Express 5, `lazyrouter` is no longer used, and the [setting of `req`/`res` prototypes is now done synchronously within the `app.handle` function](https://github.com/expressjs/express/blob/2eb42059f33d9be6ead3bb813d05aa975283d592/lib/application.js#L168-L170) instead of individual middleware, making it difficult to override this logic.

  To solve this, we changed `app.request`/`app.response` to getters that enable one-shot value overrides similar to Jest's `mockReturnValueOnce`. When HTTP2 requests/responses are received, we perform this override just before calling `app.handle`. This way, when `app.request`/`app.response` are referenced within `app.handle` to set prototypes, `app.http2Request`/`app.http2Response` are returned instead, allowing the correct prototypes to be set.

  Since [all processing from calling app.handle to referencing `app.request`/`app.response` within it is done synchronously,](https://github.com/expressjs/express/blob/2eb42059f33d9be6ead3bb813d05aa975283d592/lib/application.js#L153-L166) the overridden `app.request`/`app.response` will never be used for unintended requests, ensuring safety.

## Changes for setting powered by

The logic for setting `X-Powered-By` has also been moved into app.handle.  Unlike the previous request/response handling, it's impossible to modify this logic from outside, so in practice we need to override the `X-Powered-By` value afterwards.

 Here we use the same approach as before, using middleware to override it later. However, since `lazyrouter` has been removed, we need to find an alternative place where we can inject the middleware use processing. The equivalent of `lazyrouter` functionality was moved in [this commit](https://github.com/expressjs/express/commit/509ebb1aff11749a9608f2a1ed2117766800d883) to define a router getter within `app.init`, so by calling `router.use` immediately after `app.init` is called, we can inject the `X-Powered-By` setting middleware with the highest priority.


## Why not change the prototype at the same time as setting x-powered-by?

   Ideally, it would be simpler if we could override the prototype within middleware just like in Express v4, but unfortunately this doesn't work.  While the detailed cause hasn't been investigated, it appears that overriding the prototype via middleware is too late in the timing, or because the prototype temporarily becomes `IncomingMessage` (HTTP1 `ServerRequest`), `IncomingMessage` methods (like `_read`) are almost certainly called, resulting in errors. For this reason, we needed to use a mechanism that prevents any inappropriate prototype setting from occurring in the first place, as explained initially.

